### PR TITLE
Add service workers registration and push notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ npm-debug.log
 test/unit/coverage
 test/e2e/reports
 selenium-debug.log
+
+// Avoid credentials and local config
+.env

--- a/index.js
+++ b/index.js
@@ -19,8 +19,10 @@ app.set('superSecret', config.secret); // secret variable
 app.use(bodyParser.json()); // for parsing application/json
 app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
 
-// VAPID keys should only be generated only once.
-//const vapidKeys = webpush.generateVAPIDKeys();
+const vapidKeys = {
+    publicKey: 'BP5DsTGZtwA4cqV1vgTggxDdy-6fBY5I--_3fPCHAir9kUS5rR_vAzHKc0htxxGx_sFz-02liGu8PgoZr9DEr3Y',
+    privateKey: process.env.QOWALA_VAPID_PRIVATE
+  };
 
 webpush.setVapidDetails(
   'mailto:admin@qowala.org',

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ app.use(bodyParser.json()); // for parsing application/json
 app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
 
 const vapidKeys = {
-    publicKey: 'BP5DsTGZtwA4cqV1vgTggxDdy-6fBY5I--_3fPCHAir9kUS5rR_vAzHKc0htxxGx_sFz-02liGu8PgoZr9DEr3Y',
+    publicKey: process.env.QOWALA_VAPID_PUBLIC,
     privateKey: process.env.QOWALA_VAPID_PRIVATE
   };
 
@@ -258,6 +258,7 @@ io.on('connection', function(socket){
           token: jwt.sign(user, app.get('superSecret'), {
             expiresIn: 86400 // expires in 24 hours
           }),
+          applicationServerPublicKey: process.env.QOWALA_VAPID_PUBLIC,
           availability: users[credentials.email].availability
         };
         startFacebook(user, users, socket);

--- a/package.json
+++ b/package.json
@@ -2,29 +2,28 @@
   "name": "qowala",
   "version": "0.1.0",
   "description": "Messaging app for a better living",
-  "author": "Killian Kemps <killian.kemps@etu-webschoolfactory.fr>",
+  "author": "Killian Kemps",
   "private": true,
   "scripts": {
     "start": "node index.js"
   },
   "dependencies": {
-		"facebook-chat-api": "^1.2.0",
-		"socket.io": "^1.5.1",
-		"express": "^4.14.0",
-		"client-sessions": "^0.7.0",
     "body-parser": "^1.15.2",
-    "jsonwebtoken": "^7.1.9"
+    "client-sessions": "^0.7.0",
+    "express": "^4.14.0",
+    "facebook-chat-api": "^1.2.0",
+    "jsonwebtoken": "^7.1.9",
+    "socket.io": "^1.5.1",
+    "web-push": "^3.2.1"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "engines": {
     "node": ">= 4.0.0",
     "npm": ">= 3.0.0"
   },
-	"repository": {
-		"type": "git",
-		"url": "git@git.framasoft.org:KillianKemps/Qowala.git"
-	},
- "author": "Killian Kemps",
- "license": "ISC"
+  "repository": {
+    "type": "git",
+    "url": "git@git.framasoft.org:KillianKemps/Qowala.git"
+  },
+  "license": "ISC"
 }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "author": "Killian Kemps",
   "private": true,
   "scripts": {
-    "start": "node index.js"
+    "setup": "node setup.js",
+    "start": "node -r dotenv/config index.js"
   },
   "dependencies": {
     "body-parser": "^1.15.2",
     "client-sessions": "^0.7.0",
+    "dotenv": "^4.0.0",
     "express": "^4.14.0",
     "facebook-chat-api": "^1.2.0",
     "jsonwebtoken": "^7.1.9",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "scripts": {
     "setup": "node setup.js",
-    "start": "node -r dotenv/config index.js"
+    "start": "node index.js",
+    "dev": "NODE_ENV=development node -r dotenv/config index.js"
   },
   "dependencies": {
     "body-parser": "^1.15.2",

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,15 @@
+'use strict'
+const webpush = require('web-push');
+
+// VAPID keys should only be generated only once.
+const vapidKeys = webpush.generateVAPIDKeys();
+
+const fs = require('fs');
+const VAPID_PRIVATE_ENV = '\n' + 'QOWALA_VAPID_PRIVATE=' + vapidKeys.privateKey;
+const VAPID_PUBLIC_ENV = '\n' + 'QOWALA_VAPID_PUBLIC=' + vapidKeys.publicKey;
+
+// Write Vapid keys in env file
+fs.appendFile('.env', VAPID_PRIVATE_ENV, function (err) {
+});
+fs.appendFile('.env', VAPID_PUBLIC_ENV, function (err) {
+});


### PR DESCRIPTION
## Description
Add notifications through Service Worker's Push Notification API

## Reason why
It allows to get notifications even if Qowala's window is closed. It is especially useful on mobile where user's are not used to keep the browser open.

Warning: To develop, the command will now be `npm run dev` instead of `npm start`. It will perform specific tasks for development environment
First time use will require do first to a `npm run setup` before a `npm run dev`

Taiga Link: https://tree.taiga.io/project/qowala-live/us/167?milestone=100671