### PR TITLE
Fix notification and synchronization when using several sessions

### DIFF
--- a/index.js
+++ b/index.js
@@ -332,6 +332,8 @@ io.on('connection', function(socket){
         if (currentUser) {
           console.log('availability updated to: ', payload.availability);
           currentUser.availability = payload.availability;
+          // Broadcast to other devices of same user
+          io.to(decoded.email).emit('return/availability', currentUser.availability);
         }
         else {
           socket.emit('need auth');

--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ function startFacebook(decoded, users, socket) {
               senderImage: data[0].img,
               isSenderUser: message.senderID === currentUser.ID.toString()
             }
-            socket.emit('chat message', msgToSend);
+            io.to(decoded.email).emit('chat message', msgToSend);
 
             msgNotification = {
               title: msgToSend.senderName,
@@ -271,6 +271,7 @@ io.on('connection', function(socket){
           availability: users[credentials.email].availability
         };
         startFacebook(user, users, socket);
+        socket.join(user.email);
         socket.emit('login ok', payload);
       }
     ).catch(function(err) {

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ function startFacebook(decoded, users, socket) {
             msgNotification = {
               title: msgToSend.senderName,
               body: msgToSend.body,
-              icon: '/static/img/favicon.png'
+              icon: '/img/favicon.png'
             };
 
             if (currentUser.availability === 'available') {


### PR DESCRIPTION
## Description
- Avoid creating a new listener when one already exist
- Synchronize live messages across all user's devices
- Synchronize availability status across all user's devices
- Fix favicon image path for service worker

## Reason why
There were some duplicates listeners causing to have multiple notifications for same message.

Behaviour it will now have:
 - Websockets are kept connected on all devices where the users has logged in
 - Push Notifications through Service Workers will only affect the last device on which the user has logged in